### PR TITLE
fix `I2CInterface` (without Irq pin) `InterfaceError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- fix `I2CInterface` (without Irq pin) `InterfaceError` #14
+
 ## [0.3.1]
 
 ### Fixed

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -16,6 +16,10 @@ pub const PN532_I2C_READY: u8 = 0x01;
 pub const I2C_ADDRESS: u8 = 0x24;
 
 /// I2C Interface without IRQ pin
+///
+/// # Note:
+/// Currently the implementation of [`I2CInterface::wait_ready`] ignores any I2C errors.
+/// See this [issue](https://github.com/WMT-GmbH/pn532/issues/4) for an explanation.
 #[derive(Clone, Debug)]
 pub struct I2CInterface<I2C>
 where
@@ -42,7 +46,10 @@ where
 
     fn wait_ready(&mut self) -> Poll<Result<(), Self::Error>> {
         let mut buf = [0];
-        self.i2c.read(I2C_ADDRESS, &mut buf)?;
+        self.i2c.read(I2C_ADDRESS, &mut buf).ok();
+        // It's possible that the PN532 does not ACK the read request when it is not ready.
+        // Since we don't know the concrete type of `Self::Error` unfortunately we have to ignore all interface errors here.
+        // See https://github.com/WMT-GmbH/pn532/issues/4 for more info
 
         if buf[0] == PN532_I2C_READY {
             Poll::Ready(Ok(()))

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -402,7 +402,7 @@ impl<'a, I: Interface> Future for WaitReadyFuture<'a, I> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let poll = self.interface.wait_ready();
         if poll.is_pending() {
-            // tell the excecutor to poll this future again
+            // tell the executor to poll this future again
             cx.waker().clone().wake();
         }
         poll


### PR DESCRIPTION
fixes #4