### PR TITLE
able to make any request, e.g. from any slice

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -8,7 +8,7 @@ use core::{
 use embedded_hal::timer::CountDown;
 
 use crate::{
-    requests::{BorrowedRequest, Command},
+    requests::{BorrowRequest, BorrowedRequest, Command},
     Interface, Request,
 };
 
@@ -175,7 +175,7 @@ impl<I: Interface, T, const N: usize> Pn532<I, T, N> {
     /// pn532.send(&Request::GET_FIRMWARE_VERSION);
     /// ```
     #[inline]
-    pub fn send<const M: usize>(&mut self, request: &Request<M>) -> Result<(), Error<I::Error>> {
+    pub fn send(&mut self, request: &impl BorrowRequest) -> Result<(), Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
         self._send(request.borrow())
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -8,7 +8,7 @@ use core::{
 use embedded_hal::timer::CountDown;
 
 use crate::{
-    requests::{BorrowRequest, BorrowedRequest, Command},
+    requests::{BorrowedRequest, Command},
     Interface,
 };
 
@@ -91,12 +91,12 @@ impl<I: Interface, T: CountDown, const N: usize> Pn532<I, T, N> {
     #[inline]
     pub fn process<'a>(
         &mut self,
-        request: impl BorrowRequest<'a>,
+        request: impl Into<BorrowedRequest<'a>>,
         response_len: usize,
         timeout: T::Time,
     ) -> Result<&[u8], Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
-        self._process(request.borrow(), response_len, timeout)
+        self._process(request.into(), response_len, timeout)
     }
     fn _process(
         &mut self,
@@ -134,11 +134,11 @@ impl<I: Interface, T: CountDown, const N: usize> Pn532<I, T, N> {
     #[inline]
     pub fn process_no_response<'a>(
         &mut self,
-        request: impl BorrowRequest<'a>,
+        request: impl Into<BorrowedRequest<'a>>,
         timeout: T::Time,
     ) -> Result<(), Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
-        self._process_no_response(request.borrow(), timeout)
+        self._process_no_response(request.into(), timeout)
     }
     fn _process_no_response(
         &mut self,
@@ -175,9 +175,9 @@ impl<I: Interface, T, const N: usize> Pn532<I, T, N> {
     /// pn532.send(&Request::GET_FIRMWARE_VERSION);
     /// ```
     #[inline]
-    pub fn send<'a>(&mut self, request: impl BorrowRequest<'a>) -> Result<(), Error<I::Error>> {
+    pub fn send<'a>(&mut self, request: impl Into<BorrowedRequest<'a>>) -> Result<(), Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
-        self._send(request.borrow())
+        self._send(request.into())
     }
     fn _send(&mut self, request: BorrowedRequest<'_>) -> Result<(), Error<I::Error>> {
         let data_len = request.data.len();
@@ -302,11 +302,11 @@ impl<I: Interface, const N: usize> Pn532<I, (), N> {
     #[inline]
     pub async fn process_async<'a>(
         &mut self,
-        request: impl BorrowRequest<'a>,
+        request: impl Into<BorrowedRequest<'a>>,
         response_len: usize,
     ) -> Result<&[u8], Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
-        self._process_async(request.borrow(), response_len).await
+        self._process_async(request.into(), response_len).await
     }
     async fn _process_async(
         &mut self,
@@ -332,10 +332,10 @@ impl<I: Interface, const N: usize> Pn532<I, (), N> {
     #[inline]
     pub async fn process_no_response_async<'a>(
         &mut self,
-        request: impl BorrowRequest<'a>,
+        request: impl Into<BorrowedRequest<'a>>,
     ) -> Result<(), Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
-        self._process_no_response_async(request.borrow()).await
+        self._process_no_response_async(request.into()).await
     }
     async fn _process_no_response_async(
         &mut self,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -9,7 +9,7 @@ use embedded_hal::timer::CountDown;
 
 use crate::{
     requests::{BorrowRequest, BorrowedRequest, Command},
-    Interface, Request,
+    Interface,
 };
 
 const PREAMBLE: [u8; 3] = [0x00, 0x00, 0xFF];
@@ -89,9 +89,9 @@ impl<I: Interface, T: CountDown, const N: usize> Pn532<I, T, N> {
     /// let result = pn532.process(&Request::GET_FIRMWARE_VERSION, 4, 50.ms());
     /// ```
     #[inline]
-    pub fn process<const M: usize>(
+    pub fn process<'a>(
         &mut self,
-        request: &Request<M>,
+        request: impl BorrowRequest<'a>,
         response_len: usize,
         timeout: T::Time,
     ) -> Result<&[u8], Error<I::Error>> {
@@ -132,9 +132,9 @@ impl<I: Interface, T: CountDown, const N: usize> Pn532<I, T, N> {
     /// pn532.process_no_response(&Request::INLIST_ONE_ISO_A_TARGET, 5.ms());
     /// ```
     #[inline]
-    pub fn process_no_response<const M: usize>(
+    pub fn process_no_response<'a>(
         &mut self,
-        request: &Request<M>,
+        request: impl BorrowRequest<'a>,
         timeout: T::Time,
     ) -> Result<(), Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
@@ -175,7 +175,7 @@ impl<I: Interface, T, const N: usize> Pn532<I, T, N> {
     /// pn532.send(&Request::GET_FIRMWARE_VERSION);
     /// ```
     #[inline]
-    pub fn send(&mut self, request: &impl BorrowRequest) -> Result<(), Error<I::Error>> {
+    pub fn send<'a>(&mut self, request: impl BorrowRequest<'a>) -> Result<(), Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
         self._send(request.borrow())
     }
@@ -300,9 +300,9 @@ impl<I: Interface, const N: usize> Pn532<I, (), N> {
     /// let future = pn532.process_async(&Request::GET_FIRMWARE_VERSION, 4);
     /// ```
     #[inline]
-    pub async fn process_async<const M: usize>(
+    pub async fn process_async<'a>(
         &mut self,
-        request: &Request<M>,
+        request: impl BorrowRequest<'a>,
         response_len: usize,
     ) -> Result<&[u8], Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
@@ -330,9 +330,9 @@ impl<I: Interface, const N: usize> Pn532<I, (), N> {
     /// let mut pn532 = get_async_pn532();
     /// let future = pn532.process_no_response_async(&Request::INLIST_ONE_ISO_A_TARGET);
     #[inline]
-    pub async fn process_no_response_async<const M: usize>(
+    pub async fn process_no_response_async<'a>(
         &mut self,
-        request: &Request<M>,
+        request: impl BorrowRequest<'a>,
     ) -> Result<(), Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
         self._process_no_response_async(request.borrow()).await

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -18,12 +18,12 @@ impl<'a> BorrowedRequest<'a> {
     }
 }
 
-pub trait BorrowRequest {
-    fn borrow(&self) -> BorrowedRequest<'_>;
+pub trait BorrowRequest<'a> {
+    fn borrow(self) -> BorrowedRequest<'a>;
 }
 
-impl<const N: usize> BorrowRequest for Request<N> {
-    fn borrow(&self) -> BorrowedRequest<'_> {
+impl<'a, const N: usize> BorrowRequest<'a> for &'a Request<N> {
+    fn borrow(self) -> BorrowedRequest<'a> {
         BorrowedRequest {
             command: self.command,
             data: &self.data,

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -7,13 +7,23 @@ pub struct Request<const N: usize> {
     pub data: [u8; N],
 }
 
-pub(crate) struct BorrowedRequest<'a> {
+pub struct BorrowedRequest<'a> {
     pub command: Command,
     pub data: &'a [u8],
 }
 
-impl<const N: usize> Request<N> {
-    pub(crate) fn borrow(&self) -> BorrowedRequest<'_> {
+impl<'a> BorrowedRequest<'a> {
+    pub fn new(command: Command, data: &'a [u8]) -> Self {
+        Self {command, data}
+    }
+}
+
+pub trait BorrowRequest {
+    fn borrow(&self) -> BorrowedRequest<'_>;
+}
+
+impl<const N: usize> BorrowRequest for Request<N> {
+    fn borrow(&self) -> BorrowedRequest<'_> {
         BorrowedRequest {
             command: self.command,
             data: &self.data,

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -20,16 +20,9 @@ impl<'a> BorrowedRequest<'a> {
     }
 }
 
-pub trait BorrowRequest<'a> {
-    fn borrow(self) -> BorrowedRequest<'a>;
-}
-
-impl<'a, const N: usize> BorrowRequest<'a> for &'a Request<N> {
-    fn borrow(self) -> BorrowedRequest<'a> {
-        BorrowedRequest {
-            command: self.command,
-            data: &self.data,
-        }
+impl<'a, const N: usize> Into<BorrowedRequest<'a>> for &'a Request<N> {
+    fn into(self) -> BorrowedRequest<'a> {
+        BorrowedRequest::new(self.command, &self.data)
     }
 }
 

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -14,7 +14,8 @@ pub struct BorrowedRequest<'a> {
 }
 
 impl<'a> BorrowedRequest<'a> {
-    pub fn new(command: Command, data: &'a [u8]) -> Self {
+    #[inline]
+    pub const fn new(command: Command, data: &'a [u8]) -> Self {
         Self {command, data}
     }
 }

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -7,6 +7,7 @@ pub struct Request<const N: usize> {
     pub data: [u8; N],
 }
 
+/// Pn532 Request consisting of a [`Command`] and a reference to extra command data
 pub struct BorrowedRequest<'a> {
     pub command: Command,
     pub data: &'a [u8],


### PR DESCRIPTION
In some cases, we cannot know the size of the data being transferred at compile time, so we need to be able to send arbitrary data. The application can also reuse the data buffer.
To achieve these goals, library users can implement the BorrowRequest trait