### PR TITLE
migrate to embedded_hal 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,6 @@ nb = "1.0.0"
 void = { version = "1.0.2", default-features = false }
 serialport = { version = "4.0.1", optional = true }
 
-esp-println = { version = "0.10.0", features = ["esp32", "log"] }
-
 [features]
 msb-spi = []
 std = ["serialport"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,12 @@ keywords = [
 ]
 
 [dependencies]
-embedded-hal = { version = "0.2.6", features = ["unproven"] }
+embedded-hal = { version = "1.0.0" }
 nb = "1.0.0"
-void = { version = "1.0.2", default_features = false }
+void = { version = "1.0.2", default-features = false }
 serialport = { version = "4.0.1", optional = true }
+
+esp-println = { version = "0.10.0", features = ["esp32", "log"] }
 
 [features]
 msb-spi = []

--- a/src/doc_test_helper.rs
+++ b/src/doc_test_helper.rs
@@ -2,51 +2,33 @@ use core::convert::Infallible;
 use core::time::Duration;
 
 use embedded_hal::spi::{SpiDevice, Operation};
-use embedded_hal::digital::OutputPin;
 use crate::CountDown;
 
 use crate::spi::SPIInterface;
 use crate::Pn532;
 
 /// used for doc tests
-pub fn get_pn532() -> Pn532<SPIInterface<NoOpSPI, NoOpCS>, NoOpTimer> {
+pub fn get_pn532() -> Pn532<SPIInterface<NoOpSPI>, NoOpTimer> {
     Pn532::new(
         SPIInterface {
             spi: NoOpSPI,
-            cs: NoOpCS,
         },
         NoOpTimer,
     )
 }
 
 /// used for doc tests
-pub fn get_async_pn532() -> Pn532<SPIInterface<NoOpSPI, NoOpCS>, ()> {
+pub fn get_async_pn532() -> Pn532<SPIInterface<NoOpSPI>, ()> {
     Pn532::new(
         SPIInterface {
             spi: NoOpSPI,
-            cs: NoOpCS,
         },
         (),
     )
 }
 
-pub struct NoOpCS;
 pub struct NoOpSPI;
 pub struct NoOpTimer;
-
-impl OutputPin for NoOpCS {
-    fn set_low(&mut self) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn set_high(&mut self) -> Result<(), Self::Error> {
-        Ok(())
-    }
-}
-
-impl embedded_hal::digital::ErrorType for NoOpCS {
-    type Error = Infallible;
-}
 
 impl SpiDevice for NoOpSPI
 {

--- a/src/doc_test_helper.rs
+++ b/src/doc_test_helper.rs
@@ -1,9 +1,9 @@
 use core::convert::Infallible;
 use core::time::Duration;
 
-use embedded_hal::blocking::spi::{Transfer, Write};
-use embedded_hal::digital::v2::OutputPin;
-use embedded_hal::timer::CountDown;
+use embedded_hal::spi::{SpiDevice, Operation};
+use embedded_hal::digital::OutputPin;
+use crate::CountDown;
 
 use crate::spi::SPIInterface;
 use crate::Pn532;
@@ -35,8 +35,6 @@ pub struct NoOpSPI;
 pub struct NoOpTimer;
 
 impl OutputPin for NoOpCS {
-    type Error = Infallible;
-
     fn set_low(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -46,24 +44,24 @@ impl OutputPin for NoOpCS {
     }
 }
 
-impl Write<u8> for NoOpSPI {
+impl embedded_hal::digital::ErrorType for NoOpCS {
     type Error = Infallible;
+}
 
-    fn write(&mut self, _: &[u8]) -> Result<(), Self::Error> {
+impl SpiDevice for NoOpSPI
+{
+    fn transaction(&mut self, _operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
-impl Transfer<u8> for NoOpSPI {
+impl embedded_hal::spi::ErrorType for NoOpSPI{
     type Error = Infallible;
-
-    fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
-        Ok(words)
-    }
 }
 
 impl CountDown for NoOpTimer {
     type Time = Duration;
+    type Error = nb::Error<void::Void>;
 
     fn start<T>(&mut self, _: T)
     where

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,11 +1,9 @@
 //! I2C interfaces
-
 use core::convert::Infallible;
 use core::fmt::Debug;
 use core::task::Poll;
 
-use embedded_hal::blocking::i2c::{Operation, Read, Transactional, Write};
-use embedded_hal::digital::v2::InputPin;
+use embedded_hal::digital::InputPin;
 
 use crate::Interface;
 
@@ -23,22 +21,16 @@ pub const I2C_ADDRESS: u8 = 0x24;
 #[derive(Clone, Debug)]
 pub struct I2CInterface<I2C>
 where
-    I2C: Transactional,
-    I2C: Write<Error = <I2C as Transactional>::Error>,
-    I2C: Read<Error = <I2C as Transactional>::Error>,
-    <I2C as Transactional>::Error: Debug,
+    I2C: embedded_hal::i2c::I2c,
 {
     pub i2c: I2C,
 }
 
 impl<I2C> Interface for I2CInterface<I2C>
 where
-    I2C: Transactional,
-    I2C: Write<Error = <I2C as Transactional>::Error>,
-    I2C: Read<Error = <I2C as Transactional>::Error>,
-    <I2C as Transactional>::Error: Debug,
+    I2C: embedded_hal::i2c::I2c,
 {
-    type Error = <I2C as Transactional>::Error;
+    type Error = I2C::Error;
 
     fn write(&mut self, frame: &[u8]) -> Result<(), Self::Error> {
         self.i2c.write(I2C_ADDRESS, frame)
@@ -59,10 +51,11 @@ where
     }
 
     fn read(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
-        self.i2c.exec(
-            I2C_ADDRESS,
-            &mut [Operation::Read(&mut [0]), Operation::Read(buf)],
-        )
+        let mut local_buf = [0u8;32];
+        let local_buf_slice = &mut local_buf[..buf.len()+1]; // read one more than buf
+        self.i2c.read( I2C_ADDRESS, local_buf_slice)?;
+        buf.copy_from_slice(&local_buf_slice[1..]);
+        Ok(())
     }
 }
 
@@ -70,10 +63,7 @@ where
 #[derive(Clone, Debug)]
 pub struct I2CInterfaceWithIrq<I2C, IRQ>
 where
-    I2C: Transactional,
-    I2C: Write<Error = <I2C as Transactional>::Error>,
-    I2C: Read<Error = <I2C as Transactional>::Error>,
-    <I2C as Transactional>::Error: Debug,
+    I2C: embedded_hal::i2c::I2c,
     IRQ: InputPin<Error = Infallible>,
 {
     pub i2c: I2C,
@@ -82,13 +72,10 @@ where
 
 impl<I2C, IRQ> Interface for I2CInterfaceWithIrq<I2C, IRQ>
 where
-    I2C: Transactional,
-    I2C: Write<Error = <I2C as Transactional>::Error>,
-    I2C: Read<Error = <I2C as Transactional>::Error>,
-    <I2C as Transactional>::Error: Debug,
+    I2C: embedded_hal::i2c::I2c,
     IRQ: InputPin<Error = Infallible>,
 {
-    type Error = <I2C as Transactional>::Error;
+    type Error = <I2C as embedded_hal::i2c::ErrorType>::Error;
 
     fn write(&mut self, frame: &[u8]) -> Result<(), Self::Error> {
         self.i2c.write(I2C_ADDRESS, frame)
@@ -104,9 +91,6 @@ where
     }
 
     fn read(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
-        self.i2c.exec(
-            I2C_ADDRESS,
-            &mut [Operation::Read(&mut [0]), Operation::Read(buf)],
-        )
+        self.i2c.read( I2C_ADDRESS,buf)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ use core::fmt::Debug;
 use core::task::Poll;
 use core::time::Duration;
 
-pub use crate::protocol::{Error, Pn532};
+pub use crate::protocol::{Error, Pn532, CountDown};
 pub use crate::requests::Request;
 
 pub mod i2c;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -5,8 +5,6 @@ use core::{
     task::{Context, Poll},
 };
 
-use embedded_hal::timer::CountDown;
-
 use crate::{
     requests::{BorrowedRequest, Command},
     Interface,
@@ -73,6 +71,24 @@ pub struct Pn532<I, T, const N: usize = 32> {
     pub interface: I,
     pub timer: T,
     buf: [u8; N],
+}
+
+// pub trait CountDown {
+//     type Time;
+//     type Error;
+//     fn start(time: Self::Time);
+//     fn wait() -> Result<(), Self::Error>;
+//
+pub trait CountDown {
+    type Error;
+    type Time;
+
+    /// Starts a new count down
+    fn start<T>(&mut self, count: T)
+    where
+        T: Into<Self::Time>;
+
+    fn wait(&mut self) -> Result<(), Self::Error>;
 }
 
 impl<I: Interface, T: CountDown, const N: usize> Pn532<I, T, N> {

--- a/src/serialport.rs
+++ b/src/serialport.rs
@@ -4,7 +4,7 @@ use core::task::Poll;
 use std::io::Write;
 use std::time::{Duration, Instant};
 
-use embedded_hal::timer::CountDown;
+use crate::protocol::CountDown;
 use serialport::SerialPort;
 
 use crate::Interface;
@@ -68,6 +68,7 @@ impl Default for SysTimer {
 
 impl CountDown for SysTimer {
     type Time = Duration;
+    type Error = nb::Error<void::Void>;
 
     fn start<T>(&mut self, count: T)
     where

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -10,7 +10,7 @@ use core::fmt::Debug;
 use core::task::Poll;
 
 use embedded_hal::spi::SpiDevice;
-use embedded_hal::digital::{InputPin, OutputPin};
+use embedded_hal::digital::InputPin;
 
 use crate::Interface;
 


### PR DESCRIPTION
I migrated the code to use embedded_hal 1.0 .

1. It compiles. I had to add a CountDown which was removed from embedded_hal.
2. Tested I2C to work with ESP32. It actually required some change due to esp-hal not fully compliant with embedded-hal. This was reported and confirmed there to be an issue they will resolve. Currently the solution assumes max buffer of 32 bytes, probably need to get that value propagated from PN532 which has `N` as a generic const value. For now, since this isn't final I didn't do it yet.
3. Tested with SPI, it doesn't work on esp32, I guess it is either due to how I setup the SPI on the esp32. When I get the logic analyzer I'll try to troubleshoot further.

Happy for others to test it with other devices, or if anyone can get it to work with esp32 I'd be happy to know how.
