### PR TITLE
Async implementation for both I2C and SPI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,18 @@ keywords = [
 
 [dependencies]
 embedded-hal = { version = "1.0.0" }
-nb = "1.0.0"
+embassy-time = { version = "0.3.2" }
+
+nb = { version = "1.0.0" }
 serialport = { version = "4.0.1", optional = true }
+
+embedded-hal-async = { version = "1.0.0" }
+maybe-async = { version = "0.2.10" }
 
 [features]
 msb-spi = []
 std = ["serialport"]
+is_sync = ["maybe-async/is_sync"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = [
 
 [dependencies]
 embedded-hal = { version = "1.0.0" }
-embassy-time = { version = "0.3.2" }
+embassy-time = { version = "0.4.0" }
 
 nb = { version = "1.0.0" }
 serialport = { version = "4.0.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ embedded-hal-async = { version = "1.0.0" }
 maybe-async = { version = "0.2.10" }
 
 [features]
+default = ["is_sync"]
 msb-spi = []
 std = ["serialport"]
 is_sync = ["maybe-async/is_sync"]
@@ -37,7 +38,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [[example]]
 name = "hsu-test-util"
-required-features = ["std"]
+required-features = ["std", "is_sync"]
 
 [dev-dependencies]
 # hsu-test-serialport

--- a/src/doc_test_helper.rs
+++ b/src/doc_test_helper.rs
@@ -9,12 +9,12 @@ use crate::Pn532;
 
 /// used for doc tests
 pub fn get_pn532() -> Pn532<SPIInterface<NoOpSPI>, NoOpTimer> {
-    Pn532::new(SPIInterface { spi: NoOpSPI }, NoOpTimer)
+    Pn532::new(SPIInterface::new(NoOpSPI), NoOpTimer)
 }
 
 /// used for doc tests
 pub fn get_async_pn532() -> Pn532<SPIInterface<NoOpSPI>, ()> {
-    Pn532::new(SPIInterface { spi: NoOpSPI }, ())
+    Pn532::new(SPIInterface::new(NoOpSPI), ())
 }
 
 pub struct NoOpSPI;

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,10 +1,19 @@
 //! I2C interfaces
-use core::convert::Infallible;
 use core::fmt::Debug;
+
+#[cfg(feature = "is_sync")]
+use core::convert::Infallible;
+#[cfg(feature = "is_sync")]
 use core::task::Poll;
+#[cfg(feature = "is_sync")]
+use embedded_hal::digital::InputPin;
+#[cfg(feature = "is_sync")]
+use embedded_hal::i2c::I2c as embedded_I2c;
+
+#[cfg(not(feature = "is_sync"))]
+use embedded_hal_async::i2c::I2c as embedded_I2c;
 
 use crate::Interface;
-use embedded_hal::digital::InputPin;
 use embedded_hal::i2c::Operation;
 
 /// To be used in `Interface::wait_ready` implementations
@@ -21,21 +30,25 @@ pub const I2C_ADDRESS: u8 = 0x24;
 #[derive(Clone, Debug)]
 pub struct I2CInterface<I2C>
 where
-    I2C: embedded_hal::i2c::I2c,
+    I2C: embedded_I2c,
 {
     pub i2c: I2C,
 }
 
+#[maybe_async::maybe_async(AFIT)]
 impl<I2C> Interface for I2CInterface<I2C>
 where
-    I2C: embedded_hal::i2c::I2c,
+    I2C: embedded_I2c,
 {
     type Error = I2C::Error;
 
-    fn write(&mut self, frame: &mut [u8]) -> Result<(), Self::Error> {
-        self.i2c.write(I2C_ADDRESS, frame)
+    async fn write(&mut self, frame: &mut [u8]) -> Result<(), Self::Error> {
+        self.i2c.write(I2C_ADDRESS, frame).await
     }
 
+    // wait_ready implementations differ between sync / async
+
+    #[maybe_async::sync_impl]
     fn wait_ready(&mut self) -> Poll<Result<(), Self::Error>> {
         let mut buf = [0];
         self.i2c.read(I2C_ADDRESS, &mut buf).ok();
@@ -49,17 +62,32 @@ where
             Poll::Pending
         }
     }
+    #[maybe_async::async_impl]
+    async fn wait_ready(&mut self) -> Result<(), Self::Error> {
+        let mut buf = [0];
+        while buf[0] != PN532_I2C_READY {
+            let _ = self.i2c.read(I2C_ADDRESS, &mut buf).await;
+            // It's possible that the PN532 does not ACK the read request when it is not ready.
+            // Since we don't know the concrete type of `Self::Error` unfortunately we have to ignore all interface errors here.
+            // See https://github.com/WMT-GmbH/pn532/issues/4 for more info
+        }
+        Ok(())
+    }
 
-    fn read(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
-        self.i2c.transaction(
-            I2C_ADDRESS,
-            &mut [Operation::Read(&mut [0]), Operation::Read(buf)],
-        )
+    async fn read(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        self.i2c
+            .transaction(
+                I2C_ADDRESS,
+                &mut [Operation::Read(&mut [0]), Operation::Read(buf)],
+            )
+            .await
     }
 }
 
 /// I2C Interface with IRQ pin
+#[maybe_async::sync_impl]
 #[derive(Clone, Debug)]
+#[maybe_async::sync_impl]
 pub struct I2CInterfaceWithIrq<I2C, IRQ>
 where
     I2C: embedded_hal::i2c::I2c,
@@ -69,6 +97,7 @@ where
     pub irq: IRQ,
 }
 
+#[maybe_async::sync_impl]
 impl<I2C, IRQ> Interface for I2CInterfaceWithIrq<I2C, IRQ>
 where
     I2C: embedded_hal::i2c::I2c,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -46,6 +46,9 @@ where
         self.i2c.write(I2C_ADDRESS, frame).await
     }
 
+    async fn wake_up(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
     // wait_ready implementations differ between sync / async
 
     #[maybe_async::sync_impl]
@@ -104,6 +107,10 @@ where
     IRQ: InputPin<Error = Infallible>,
 {
     type Error = <I2C as embedded_hal::i2c::ErrorType>::Error;
+
+    fn wake_up(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 
     fn write(&mut self, frame: &mut [u8]) -> Result<(), Self::Error> {
         self.i2c.write(I2C_ADDRESS, frame)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ pub mod requests;
 #[cfg(feature = "is_sync")]
 pub mod serialport;
 
-#[cfg(feature = "is_sync")]
 pub mod spi;
 
 /// Abstraction over the different serial links.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! # SPI example
 //! ```
 //! # use pn532::doc_test_helper::{NoOpSPI, NoOpTimer};
-//! use pn532::{requests::SAMMode, spi::SPIInterface, Pn532, Request};
+//! use pn532::{requests::SAMMode, spi::{ SPIInterface, NoIRQ}, Pn532, Request};
 //! use pn532::IntoDuration; // trait for `ms()`, your HAL might have its own
 //!
 //! # let spi = NoOpSPI;
@@ -40,7 +40,7 @@
 //! // spi is a struct implementing embedded_hal::spi::SpiDevice
 //! // timer is a struct implementing pn532::CountDown
 //!
-//! let mut pn532: Pn532<_, _, 32> = Pn532::new(SPIInterface { spi }, timer);
+//! let mut pn532: Pn532<_, _, 32> = Pn532::new(SPIInterface { spi, irq: None::<NoIRQ> }, timer);
 //! if let Err(e) = pn532.process(&Request::sam_configuration(SAMMode::Normal, false), 0, 50.ms()){
 //!     println!("Could not initialize PN532: {e:?}")
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,6 @@ pub mod spi;
 
 /// Abstraction over the different serial links.
 /// Either SPI, I2C or HSU (High Speed UART).
-
 #[cfg(feature = "is_sync")]
 pub trait Interface {
     /// Error specific to the serial link.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -2,10 +2,11 @@ use crate::{
     requests::{BorrowedRequest, Command},
     Interface,
 };
+#[cfg(feature = "is_sync")]
+use core::convert::Infallible;
+use core::{fmt::Debug, future::Future};
+#[cfg(feature = "is_sync")]
 use core::{
-    convert::Infallible,
-    fmt::Debug,
-    future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -92,9 +93,18 @@ pub trait CountDown {
         T: Into<Self::Time>;
 
     /// Non-blockingly "waits" until the count-down finishes
+    #[cfg(feature = "is_sync")]
     fn wait(&mut self) -> nb::Result<(), Infallible>;
+
+    #[cfg(not(feature = "is_sync"))]
+    fn until_timeout<F: Future>(
+        &self,
+        fut: F,
+    ) -> impl core::future::Future<Output = Result<F::Output, embassy_time::TimeoutError>>;
+    // async fn until_timeout<F: Future>(&self, fut: F) -> Result<F::Output, Self::Error>;
 }
 
+#[maybe_async::maybe_async(AFIT)]
 impl<I: Interface, T: CountDown, const N: usize> Pn532<I, T, N> {
     /// Send a request, wait for an ACK and then wait for a response.
     ///
@@ -109,16 +119,18 @@ impl<I: Interface, T: CountDown, const N: usize> Pn532<I, T, N> {
     /// let result = pn532.process(&Request::GET_FIRMWARE_VERSION, 4, 50.ms());
     /// ```
     #[inline]
-    pub fn process<'a>(
+    pub async fn process<'a>(
         &mut self,
         request: impl Into<BorrowedRequest<'a>>,
         response_len: usize,
         timeout: T::Time,
     ) -> Result<&[u8], Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
-        self._process(request.into(), response_len, timeout)
+        self._process(request.into(), response_len, timeout).await
     }
-    fn _process(
+
+    // #[maybe_async::async_impl]
+    async fn _process(
         &mut self,
         request: BorrowedRequest<'_>,
         response_len: usize,
@@ -126,19 +138,21 @@ impl<I: Interface, T: CountDown, const N: usize> Pn532<I, T, N> {
     ) -> Result<&[u8], Error<I::Error>> {
         let sent_command = request.command;
         self.timer.start(timeout);
-        self._send(request)?;
-        while self.interface.wait_ready()?.is_pending() {
-            if self.timer.wait().is_ok() {
-                return Err(Error::TimeoutAck);
-            }
+        self._send(request).await?;
+        // if self.timer.until_timeout(self.interface.wait_ready()).await.is_err() {
+        //     return Err(Error::TimeoutAck);
+        // }
+        if self._wait_ready().await.is_err() {
+            return Err(Error::TimeoutAck);
         }
-        self.receive_ack()?;
-        while self.interface.wait_ready()?.is_pending() {
-            if self.timer.wait().is_ok() {
-                return Err(Error::TimeoutResponse);
-            }
+        self.receive_ack().await?;
+        if self._wait_ready().await.is_err() {
+            return Err(Error::TimeoutResponse);
         }
-        self.receive_response(sent_command, response_len)
+        // if self.timer.until_timeout(self.interface.wait_ready()).await.is_err() {
+        //     return Err(Error::TimeoutResponse);
+        // }
+        self.receive_response(sent_command, response_len).await
     }
 
     /// Send a request and wait for an ACK.
@@ -152,29 +166,55 @@ impl<I: Interface, T: CountDown, const N: usize> Pn532<I, T, N> {
     /// pn532.process_no_response(&Request::INLIST_ONE_ISO_A_TARGET, 5.ms());
     /// ```
     #[inline]
-    pub fn process_no_response<'a>(
+
+    pub async fn process_no_response<'a>(
         &mut self,
         request: impl Into<BorrowedRequest<'a>>,
         timeout: T::Time,
     ) -> Result<(), Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
-        self._process_no_response(request.into(), timeout)
+        self._process_no_response(request.into(), timeout).await
     }
-    fn _process_no_response(
+
+    async fn _process_no_response(
         &mut self,
         request: BorrowedRequest<'_>,
         timeout: T::Time,
     ) -> Result<(), Error<I::Error>> {
         self.timer.start(timeout);
-        self._send(request)?;
+        self._send(request).await?;
+        if self._wait_ready().await.is_err() {
+            return Err(Error::TimeoutAck);
+        }
+        self.receive_ack().await
+    }
+
+    // Wait for ready byte from pn532
+    //
+    // This is different between sync and async implementations in a way that
+    // requires different functions, sync use a busy wait loop,  async use
+    // underlying async timer mechanism as provided by the caller
+
+    #[maybe_async::async_impl]
+    async fn _wait_ready(&mut self) -> Result<(), Error<I::Error>> {
+        match self.timer.until_timeout(self.interface.wait_ready()).await {
+            Err(_) => Err(Error::TimeoutResponse),
+            _ => Ok(()),
+        }
+    }
+
+    #[maybe_async::sync_impl]
+    fn _wait_ready(&mut self) -> Result<(), Error<I::Error>> {
         while self.interface.wait_ready()?.is_pending() {
             if self.timer.wait().is_ok() {
-                return Err(Error::TimeoutAck);
+                return Err(Error::TimeoutResponse);
             }
         }
-        self.receive_ack()
+        Ok(())
     }
 }
+
+#[maybe_async::maybe_async(AFIT)]
 impl<I: Interface, T, const N: usize> Pn532<I, T, N> {
     /// Create a Pn532 instance
     pub fn new(interface: I, timer: T) -> Self {
@@ -195,14 +235,14 @@ impl<I: Interface, T, const N: usize> Pn532<I, T, N> {
     /// pn532.send(&Request::GET_FIRMWARE_VERSION);
     /// ```
     #[inline]
-    pub fn send<'a>(
+    pub async fn send<'a>(
         &mut self,
         request: impl Into<BorrowedRequest<'a>>,
     ) -> Result<(), Error<I::Error>> {
         // codegen trampoline: https://github.com/rust-lang/rust/issues/77960
-        self._send(request.into())
+        self._send(request.into()).await
     }
-    fn _send(&mut self, request: BorrowedRequest<'_>) -> Result<(), Error<I::Error>> {
+    async fn _send(&mut self, request: BorrowedRequest<'_>) -> Result<(), Error<I::Error>> {
         let data_len = request.data.len();
         let frame_len = 2 + data_len as u8; // frame identifier + command + data
 
@@ -228,7 +268,7 @@ impl<I: Interface, T, const N: usize> Pn532<I, T, N> {
         self.buf[7 + data_len] = to_checksum(data_sum);
         self.buf[8 + data_len] = POSTAMBLE;
 
-        self.interface.write(&mut self.buf[..9 + data_len])?;
+        self.interface.write(&mut self.buf[..9 + data_len]).await?;
         Ok(())
     }
 
@@ -247,9 +287,9 @@ impl<I: Interface, T, const N: usize> Pn532<I, T, N> {
     ///     pn532.receive_ack();
     /// }
     /// ```
-    pub fn receive_ack(&mut self) -> Result<(), Error<I::Error>> {
+    pub async fn receive_ack(&mut self) -> Result<(), Error<I::Error>> {
         let mut ack_buf = [0; 6];
-        self.interface.read(&mut ack_buf)?;
+        self.interface.read(&mut ack_buf).await?;
         if ack_buf != ACK {
             Err(Error::BadAck)
         } else {
@@ -279,14 +319,14 @@ impl<I: Interface, T, const N: usize> Pn532<I, T, N> {
     ///     let result = pn532.receive_response(Request::GET_FIRMWARE_VERSION.command, 4);
     /// }
     /// ```
-    pub fn receive_response(
+    pub async fn receive_response(
         &mut self,
         sent_command: Command,
         response_len: usize,
     ) -> Result<&[u8], Error<I::Error>> {
         let response_buf = &mut self.buf[..response_len + 9];
         response_buf.fill(0); // zero out buf
-        self.interface.read(response_buf)?;
+        self.interface.read(response_buf).await?;
         let expected_response_command = sent_command as u8 + 1;
         parse_response(response_buf, expected_response_command)
     }
@@ -295,13 +335,14 @@ impl<I: Interface, T, const N: usize> Pn532<I, T, N> {
     /// In that case, the PN532 discontinues the last processing and does not answer anything
     /// to the host controller.
     /// Then, the PN532 starts again waiting for a new command.
-    pub fn abort(&mut self) -> Result<(), Error<I::Error>> {
+    pub async fn abort(&mut self) -> Result<(), Error<I::Error>> {
         #[allow(const_item_mutation)]
-        self.interface.write(&mut ACK)?;
+        self.interface.write(&mut ACK).await?;
         Ok(())
     }
 }
 
+#[maybe_async::sync_impl]
 impl<I: Interface, const N: usize> Pn532<I, (), N> {
     /// Create a Pn532 instance without a timer
     pub fn new_async(interface: I) -> Self {
@@ -421,10 +462,12 @@ fn parse_response<E: Debug>(
     Ok(&response_buf[7..5 + frame_len as usize])
 }
 
+#[maybe_async::sync_impl]
 struct WaitReadyFuture<'a, I> {
     interface: &'a mut I,
 }
 
+#[maybe_async::sync_impl]
 impl<'a, I: Interface> Future for WaitReadyFuture<'a, I> {
     type Output = Result<(), I::Error>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -106,6 +106,13 @@ pub trait CountDown {
 
 #[maybe_async::maybe_async(AFIT)]
 impl<I: Interface, T: CountDown, const N: usize> Pn532<I, T, N> {
+    /// Wake up the PN532 prior to any other interaction with it
+    /// Required when using SPI.
+    #[inline]
+    pub async fn wake_up(&mut self) -> Result<(), I::Error> {
+        self.interface.wake_up().await
+    }
+
     /// Send a request, wait for an ACK and then wait for a response.
     ///
     /// `response_len` is the largest expected length of the returned data.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -204,7 +204,6 @@ impl<I: Interface, T: CountDown, const N: usize> Pn532<I, T, N> {
     /// pn532.process_no_response(&Request::INLIST_ONE_ISO_A_TARGET, 5.ms());
     /// ```
     #[inline]
-
     pub async fn process_no_response<'a>(
         &mut self,
         request: impl Into<BorrowedRequest<'a>>,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -68,7 +68,7 @@ impl<E: Debug> From<E> for Error<E> {
 ///   [`receive_response`](Pn532::receive_response), [`process`](Pn532::process) or [`process_async`](Pn532::process_async)
 /// * `M` is the largest const generic type parameter of [`Request`](crate::requests::Request) references passed to any sending methods of this struct
 #[derive(Clone, Debug)]
-pub struct Pn532<I, T, const N: usize = 32> {
+pub struct Pn532<I, T, const N: usize = 64> {
     pub interface: I,
     pub timer: T,
     buf: [u8; N],

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -98,6 +98,26 @@ impl Request<0> {
             ],
         )
     }
+
+    // response size to use: 9 (1 for error/ok + 8 for real response data)
+    pub const fn ntag_get_version() -> Request<1> {
+        Request::new(
+            Command::InCommunicateThru,
+            [
+                NTAGCommand::GetVersion as u8,
+            ],
+        )
+    }
+
+    // response size to use: 0
+    #[allow(non_snake_case)]
+    pub const fn pn532_set_timeout(fATR_RES_Timeout:u8,  fRetryTimeout:u8 ) -> Request<4> {
+        let rf_configuration_timeout_sub_command = 0x02;
+        Request::new(
+            Command::RFConfiguration,
+            [rf_configuration_timeout_sub_command, 0, fATR_RES_Timeout, fRetryTimeout],
+        )
+    }
 }
 
 /// Commands supported by the Pn532

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -45,6 +45,100 @@ impl Request<0> {
     pub const RELEASE_TAG_1: Request<1> = Request::new(Command::InRelease, [1]);
     pub const RELEASE_TAG_2: Request<1> = Request::new(Command::InRelease, [2]);
 
+    pub fn tg_init_as_target(mode: Option<u8>, short_uid: Option<[u8;3]>) -> Request<37> {
+        let uid = short_uid.unwrap_or([0u8,0,0]);
+        let mode = mode.unwrap_or(0x00);
+
+        Request::new(Command::TgInitAsTarget, [
+                // From pn532 python library
+                mode, 
+                // MIFARE PARAMS
+                0x08, 0x00, 
+                uid[0], uid[1], uid[2], 
+                0x60, 
+
+                // FELICA PARAMS
+                0x01, 0xFE, 
+                0xA2, 0xA3, 0xA4, 
+                0xA5, 0xA6, 0xA7, 
+                0xC0, 0xC1, 
+                0xC2, 0xC3, 0xC4, 
+                0xC5, 0xC6, 0xC7, 
+                0xFF, 0xFF, 
+
+                0xAA, 0x99, 0x88, 
+                0x77, 0x66, 0x55, 0x44, 
+                0x33, 0x22, 0x11, 
+
+                0x00, 
+                0x00
+            ])
+
+    }
+
+    pub const TG_INIT_AS_TARGET1: Request<37> = Request::new(Command::TgInitAsTarget, [
+        // From pn532 python library
+        0x04, 
+        // MIFARE PARAMS
+        0x08, 0x00, 
+        0x11, 0x22, 0x33, 
+        0x60, 
+
+        // FELICA PARAMS
+        0x01, 0xFE, 
+        0xA2, 0xA3, 0xA4, 
+        0xA5, 0xA6, 0xA7, 
+        0xC0, 0xC1, 
+        0xC2, 0xC3, 0xC4, 
+        0xC5, 0xC6, 0xC7, 
+        0xFF, 0xFF, 
+
+        0xAA, 0x99, 0x88, 
+        0x77, 0x66, 0x55, 0x44, 
+        0x33, 0x22, 0x11, 
+
+        0x00, 
+        0x00
+    ]);
+
+    pub const TG_INIT_AS_TARGET2: Request<37> = Request::new(Command::TgInitAsTarget, [
+        // one version from elechouse pn532
+        5,                  // MODE: PICC only, Passive only
+
+        0x04, 0x00,         // SENS_RES
+        0x00, 0x00, 0x00,   // NFCID1
+        0x20,               // SEL_RES
+
+        0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,   // FeliCaParams
+        0,0,
+
+        0,0,0,0,0,0,0,0,0,0, // NFCID3t
+
+        0, // length of general bytes
+        0  // length of historical bytes
+    ]);
+
+    pub const TG_INIT_AS_TARGET3: Request<43> = Request::new(Command::TgInitAsTarget, [
+        // another version from elechouse pn532 (called Peer to Peer, not sure correctly)
+        0,
+        0x00, 0x00,         //SENS_RES
+        0x00, 0x00, 0x00,   //NFCID1
+        0x40,               //SEL_RES
+
+        0x01, 0xFE, 0x0F, 0xBB, 0xBA, 0xA6, 0xC9, 0x89, // POL_RES
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0xFF, 0xFF,
+
+        0x01, 0xFE, 0x0F, 0xBB, 0xBA, 0xA6, 0xC9, 0x89, 0x00, 0x00, //NFCID3t: Change this to desired value
+
+        0x06, 0x46,  0x66, 0x6D, 0x01, 0x01, 0x10, 0x00// LLCP magic number and version parameter
+    ]);
+
+
+    // Response Size:
+    pub const TG_GET_DATA: Request<0> = Request::new(Command::TgGetData, []);
+
     pub const fn sam_configuration(mode: SAMMode, use_irq_pin: bool) -> Request<3> {
         // TODO use_irq_pin seems to not have any effect
         let (mode, timeout) = match mode {

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -172,6 +172,44 @@ impl Request<0> {
             ],
         )
     }
+
+    pub fn mifare_classic_authenticate_block(uid: &[u8], block_number: u8, key: MifareAuthKey) -> Request<13> {
+        let uid_last_4_bytes = &uid[uid.len()-4..];
+        let (key_type, key_val) = match &key {
+            MifareAuthKey::A(key_val) => (MifareCommand::AuthenticationWithKeyA as u8, key_val),
+            MifareAuthKey::B(key_val) => (MifareCommand::AuthenticationWithKeyB as u8, key_val),
+        };
+        Request::new(
+            Command::InDataExchange,
+            [
+                0x01,
+                key_type,
+                block_number,
+                key_val[0],
+                key_val[1],
+                key_val[2],
+                key_val[3],
+                key_val[4],
+                key_val[5],
+                uid_last_4_bytes[0],
+                uid_last_4_bytes[1],
+                uid_last_4_bytes[2],
+                uid_last_4_bytes[3],
+            ],
+        )
+    }
+
+    pub fn mifare_classic_read_data_block(block_number: u8) -> Request<3> {
+        Request::new(
+            Command::InDataExchange,
+            [
+                0x01,
+                MifareCommand::Read as u8, // TODO: use key a
+                block_number,
+            ],
+        )
+    }
+
     pub const fn ntag_pwd_auth(bytes: &[u8; 4]) -> Request<5> {
         Request::new(
             Command::InCommunicateThru,
@@ -442,4 +480,10 @@ pub enum MifareCommand {
     Increment = 0xC1,
     Restore = 0xC2,
     Transfer = 0xB0,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum MifareAuthKey<'a> {
+    A(&'a [u8;6]),
+    B(&'a [u8;6])
 }

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -47,33 +47,25 @@ impl Request<0> {
 
     pub fn tg_init_as_target(mode: Option<u8>, short_uid: Option<[u8;3]>) -> Request<37> {
         let uid = short_uid.unwrap_or([0u8,0,0]);
-        let mode = mode.unwrap_or(0x00);
+        let mode = mode.unwrap_or(0x05);
 
         Request::new(Command::TgInitAsTarget, [
-                // From pn532 python library
-                mode, 
-                // MIFARE PARAMS
-                0x08, 0x00, 
-                uid[0], uid[1], uid[2], 
-                0x60, 
+            // one version from elechouse pn532
+            mode,                     // MODE: PICC only, Passive only
 
-                // FELICA PARAMS
-                0x01, 0xFE, 
-                0xA2, 0xA3, 0xA4, 
-                0xA5, 0xA6, 0xA7, 
-                0xC0, 0xC1, 
-                0xC2, 0xC3, 0xC4, 
-                0xC5, 0xC6, 0xC7, 
-                0xFF, 0xFF, 
+            0x04, 0x00,               // SENS_RES
+            uid[0], uid[1], uid[2],   // NFCID1
+            0x20,                     // SEL_RES
 
-                0xAA, 0x99, 0x88, 
-                0x77, 0x66, 0x55, 0x44, 
-                0x33, 0x22, 0x11, 
+            0,0,0,0,0,0,0,0,
+            0,0,0,0,0,0,0,0,          // FeliCaParams
+            0,0,
 
-                0x00, 
-                0x00
-            ])
+            0,0,0,0,0,0,0,0,0,0,      // NFCID3t
 
+            0,                        // length of general bytes
+            0                         // length of historical bytes
+        ])
     }
 
     pub const TG_INIT_AS_TARGET1: Request<37> = Request::new(Command::TgInitAsTarget, [

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -280,31 +280,34 @@ mod tests {
 
     #[test]
     fn test_spi() {
-        let mut spi = SPIInterface::new(SpiMock::new(&[
-            // write
-            SpiTransaction::transaction_start(),
-            SpiTransaction::write(as_lsb(0x01)),
-            SpiTransaction::write_vec(vec![as_lsb(1), as_lsb(2)]),
-            SpiTransaction::transaction_end(),
-            // wait_ready
-            SpiTransaction::transaction_start(),
-            SpiTransaction::transfer_in_place(
-                vec![as_lsb(0x02), as_lsb(0x00)],
-                vec![as_lsb(0x00), as_lsb(0x00)],
-            ),
-            SpiTransaction::transaction_end(),
-            SpiTransaction::transaction_start(),
-            SpiTransaction::transfer_in_place(
-                vec![as_lsb(0x02), as_lsb(0x00)],
-                vec![as_lsb(0x00), as_lsb(0x01)],
-            ),
-            SpiTransaction::transaction_end(),
-            // read
-            SpiTransaction::transaction_start(),
-            SpiTransaction::write(as_lsb(0x03)),
-            SpiTransaction::read_vec(vec![as_lsb(3), as_lsb(4)]),
-            SpiTransaction::transaction_end(),
-        ]));
+        let mut spi = SPIInterface {
+            spi: SpiMock::new(&[
+                // write
+                SpiTransaction::transaction_start(),
+                SpiTransaction::write(as_lsb(0x01)),
+                SpiTransaction::write_vec(vec![as_lsb(1), as_lsb(2)]),
+                SpiTransaction::transaction_end(),
+                // wait_ready
+                SpiTransaction::transaction_start(),
+                SpiTransaction::transfer_in_place(
+                    vec![as_lsb(0x02), as_lsb(0x00)],
+                    vec![as_lsb(0x00), as_lsb(0x00)],
+                ),
+                SpiTransaction::transaction_end(),
+                SpiTransaction::transaction_start(),
+                SpiTransaction::transfer_in_place(
+                    vec![as_lsb(0x02), as_lsb(0x00)],
+                    vec![as_lsb(0x00), as_lsb(0x01)],
+                ),
+                SpiTransaction::transaction_end(),
+                // read
+                SpiTransaction::transaction_start(),
+                SpiTransaction::write(as_lsb(0x03)),
+                SpiTransaction::read_vec(vec![as_lsb(3), as_lsb(4)]),
+                SpiTransaction::transaction_end(),
+            ]),
+            irq: None::<NoIRQ>,
+        };
 
         spi.write(&mut [1, 2]).unwrap();
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -54,6 +54,9 @@ where
     SPI: SpiDevice,
 {
     type Error = <SPI as embedded_hal::spi::ErrorType>::Error;
+    async fn wake_up(&mut self) -> Result<(), Self::Error> {
+        self.spi.transaction(&mut [Operation::DelayNs(2_000_000)]).await
+    }
 
     async fn write(&mut self, frame: &mut [u8]) -> Result<(), Self::Error> {
         #[cfg(feature = "msb-spi")]
@@ -124,6 +127,10 @@ where
     IRQ: InputPin<Error = Infallible>,
 {
     type Error = <SPI as embedded_hal::spi::ErrorType>::Error;
+
+    fn wake_up(&mut self) -> Result<(), Self::Error> {
+        self.spi.transaction(&mut [Operation::DelayNs(2_000_000)])
+    }
 
     fn write(&mut self, frame: &mut [u8]) -> Result<(), Self::Error> {
         #[cfg(feature = "msb-spi")]

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -153,7 +153,7 @@ where
         match self.irq {
             Some(ref mut irq) => match irq.is_low() {
                 Ok(v) => {
-                    return if v {
+                    if v {
                         Poll::Ready(Ok(()))
                     } else {
                         Poll::Pending

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -131,7 +131,7 @@ where
     type Error = <SPI as embedded_hal::spi::ErrorType>::Error;
     async fn wake_up(&mut self) -> Result<(), Self::Error> {
         self.spi
-            .transaction(&mut [Operation::DelayNs(2_000_000)])
+            .transaction(&mut [Operation::DelayNs(10_000_000)])
             .await
     }
 


### PR DESCRIPTION
This is a first version of Async, surely needs some fine tuning, but it's working.
Was tested on ESP32S3. The I2C has been working for quite some time w/o any issues. SPI is newer.

Some notes:
1. Uses `maybe_async` to avoid code duplications, ~~ ~~therefore at this time default is async and need to set feature `is_sync` to make it sync (the default for `maybe_async`). Might want to revisit this for backwards compatibility and make sync the default.~~ default is `is_sync` and need to use `default-features=false` for async.
2. SInce `Countdown` Error type was lately removed and replaced by a specific error type (nb), I used embassy-time `TimeoutError` instead of an error type supplied by the user which I think would have been more elegant, not sure if it's good approach. For embedded probably yes since embassy is the de-facto standard and it makes life easier.
3. ~~Currently async doesn't support IRQ mode. Will probably want to add as a next step.~~ (added)
4. Needs cleanups for sure, I kept some remarks to remind me of what was before/some alternatives/etc.
5. Along the way also added `wake_up` to get SPI to work (for both sync and async).
